### PR TITLE
Fix handling of filename on redirect

### DIFF
--- a/util/fileutil.go
+++ b/util/fileutil.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 )
@@ -32,7 +33,11 @@ func DownloadFile(fileurl string, destinationdir string) (*string, error) {
 
 	defer resp.Body.Close()
 
-	filename := path.Base(resp.Request.URL.Path)
+	u, err := url.Parse(fileurl)
+	if err != nil {
+		return nil, err
+	}
+	filename := path.Base(u.Path)
 	fullpath := path.Join(destinationdir, filename)
 
 	err = os.MkdirAll(destinationdir, os.ModePerm)


### PR DESCRIPTION
Github releases are all redirects to filenames in their object store. The resulting filename from something like:

```
  - release_file: "https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/cert-manager.yaml"
    destination_dir: "cert-manager/release"
    sha256: "517b57b60e37288ced462bb541f3f5dabb53f59f40c262387403862985b01ae8"
    validation_type: "sha256"
```

is a guid rather than the expected `cert-manager.yaml`. This uses the filename from the original request instead.

Signed-off-by: Brandon Mitchell <git@bmitch.net>